### PR TITLE
Allow all valid discord handles

### DIFF
--- a/src/main/java/com/cssbham/minecraftcore/commands/CommandMakeGreen.java
+++ b/src/main/java/com/cssbham/minecraftcore/commands/CommandMakeGreen.java
@@ -26,11 +26,8 @@ public class CommandMakeGreen implements CommandExecutor {
             sender.sendMessage("Only players can execute this command.");
             return true;
         }
-        if (args.length != 1) {
-            return false;
-        }
-        String arg = args[0];
-        if (!arg.matches(".{3,32}#[0-9]{4}")) {
+        String arg = String.join(" ", args);
+        if (!arg.matches(".{2,32}#[0-9]{4}")) {
             return false;
         }
 


### PR DESCRIPTION
This fixes issue #6 to accept valid discord handles of at least 2 characters and with spaces. 