### PR TITLE
Removed dependency step in workflow

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -40,7 +40,3 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-
-      
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
It's causing anyone who doesn't have write access to have their PRs fail, and I haven't found a lot of successful use for it in context of this, so I'll just flick it off.